### PR TITLE
Set URL property of version file

### DIFF
--- a/ISPx2.version
+++ b/ISPx2.version
@@ -1,6 +1,6 @@
 {
   "NAME": "M_ISPx2",
-  "URL": "ComingSoon",
+  "URL": "https://github.com/miki-g/M-ISPx2/raw/master/ISPx2.version",
   "VERSION": {
     "MAJOR": 0,
     "MINOR": 0,
@@ -9,16 +9,16 @@
   "KSP_VERSION": {
     "MAJOR": 1,
     "MINOR": 2,
-	"PATCH": 2
+    "PATCH": 2
   },
   "KSP_VERSION_MIN": {
     "MAJOR": 1,
     "MINOR": 0,
-	"PATCH": 0
+    "PATCH": 0
   },
   "KSP_VERSION_MAX": {
     "MAJOR": 1,
     "MINOR": 5,
-	"PATCH": 9
+    "PATCH": 9
   }
 }


### PR DESCRIPTION
The "URL" property specifies an online copy of the version file that KSP-AVC and CKAN can check for updates. Now it's set to point to the copy on GitHub.

Tagging @miki-g because GitHub doesn't always send notifications for pull requests.